### PR TITLE
Migrate site to /scipy2014

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -21,6 +21,8 @@ def scipy_do(*args, **kw):
 
 
 def deploy(commit=None):
+    install_system_deps()
+
     update_repo(commit=commit)
 
     venv_path = deploy_venv()
@@ -130,3 +132,9 @@ def deploy_mail(venv_path):
     render_to_file('django_mail_template.sh', 'django_mail.sh',
                    virtualenv=venv_path)
     scipy_put('django_mail.sh', pjoin(SITE_PATH, 'bin/django_mail.sh'))
+
+
+def install_system_deps():
+    sudo('apt-get install python-virtualenv')
+    # for pillow
+    sudo('apt-get install libjpeg-dev libtiff-dev zlib1g-dev')

--- a/nginx_conf_template
+++ b/nginx_conf_template
@@ -19,11 +19,11 @@ server {
     access_log /home/scipy/site/logs/scipy.access.log;
     error_log /home/scipy/site/logs/scipy.error.log;
 
-    location /site_media/media/ {
+    location /scipy2014/site_media/media/ {
         alias /home/scipy/site/site_media/media/;
     }
 
-    location /site_media/static/ {
+    location /scipy2014/site_media/static/ {
         alias /home/scipy/site/site_media/;
     }
 

--- a/nginx_conf_template
+++ b/nginx_conf_template
@@ -27,7 +27,7 @@ server {
         alias /home/scipy/site/site_media/;
     }
 
-    location / {
+    location /scipy2014/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Ssl on;
         proxy_set_header Host $host;

--- a/nginx_conf_template
+++ b/nginx_conf_template
@@ -24,7 +24,7 @@ server {
     }
 
     location /scipy2014/site_media/static/ {
-        alias /home/scipy/site/site_media/;
+        alias /home/scipy/site/site_media/static/;
     }
 
     location /scipy2014/ {

--- a/rackspace_settings.py
+++ b/rackspace_settings.py
@@ -13,7 +13,7 @@ EMAIL_HOST_USER = secrets.email_host_user
 EMAIL_HOST_PASSWORD = secrets.email_host_password
 EMAIL_PORT = secrets.email_port
 
-STATIC_ROOT = '/home/scipy/site/site_media/'
+STATIC_ROOT = '/home/scipy/site/site_media/static/'
 MEDIA_ROOT = '/home/scipy/site/site_media/media/'
 
 INTERNAL_IPS = [

--- a/scipy2014/_urls.py
+++ b/scipy2014/_urls.py
@@ -1,0 +1,94 @@
+from django.conf import settings
+from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls.static import static
+
+from django.views.generic.simple import direct_to_template
+
+from django.contrib import admin
+
+import symposion.views
+
+# from pinax.apps.account.openid_consumer import PinaxConsumer
+
+urlpatterns = patterns(
+    "",
+    url(r"^$",
+        direct_to_template,
+        {"template": "homepage.html"},
+        name="home"),
+    url(r"^about/$",
+        direct_to_template,
+        {"template": "about/about.html"},
+        name="about"),
+    url(r'^venue/$',
+        direct_to_template,
+        {'template': 'venue/venue.html'},
+        name='venue'),
+    url(r'^lodging/$',
+        direct_to_template,
+        {'template': 'venue/lodging.html'},
+        name='lodging'),
+    url(r'^directions/$',
+        direct_to_template,
+        {'template': 'venue/directions.html'},
+        name='directions'),
+    url(r'^floorplans/$',
+        direct_to_template,
+        {'template': 'venue/floorplans.html'},
+        name='floorplans'),
+    url(r'^restaurants/$',
+        direct_to_template,
+        {'template': 'venue/restaurants.html'},
+        name='restaurants'),
+    url(r'^plotting_contest/$',
+        direct_to_template,
+        {'template': 'about/plotting_contest.html'},
+        name='plotting_contest'),
+    url(r'^organizers/$',
+        direct_to_template,
+        {'template': 'about/organizers.html'},
+        name='organizers'),
+    url(r'^diversity/$',
+        direct_to_template,
+        {'template': 'about/diversity.html'},
+        name='diversity'),
+    url(r'^code_of_conduct/$',
+        direct_to_template,
+        {'template': 'about/code_of_conduct.html'},
+        name='code_of_conduct'),
+    url(r"^admin/", include(admin.site.urls)),
+    url(r'^video_highlights/$',
+        direct_to_template,
+        {'template': 'video_highlights.html'},
+        name='video highlights'),
+    url(r'^privacy_policy/$',
+        direct_to_template,
+        {'template': 'privacy_policy.html'},
+        name='privacy_policy'),
+    url(r'^sponsorship/$',
+        direct_to_template,
+        {'template': 'sponsorship.html'},
+        name='sponsorship'),
+
+    url(r"^account/signup/$",
+        symposion.views.SignupView.as_view(),
+        name="account_signup"),
+    url(r"^account/login/$",
+        symposion.views.LoginView.as_view(),
+        name="account_login"),
+    url(r"^account/", include("account.urls")),
+
+    url(r"^dashboard/", symposion.views.dashboard, name="dashboard"),
+    url(r"^speaker/", include("symposion.speakers.urls")),
+    url(r"^proposals/", include("symposion.proposals.urls")),
+    url(r"^sponsors/", include("symposion.sponsorship.urls")),
+    url(r"^boxes/", include("symposion.boxes.urls")),
+    url(r"^teams/", include("symposion.teams.urls")),
+    url(r"^reviews/", include("symposion.reviews.urls")),
+    url(r"^schedule/", include("symposion.schedule.urls")),
+    url(r"^markitup/", include("markitup.urls")),
+
+    url(r"^", include("symposion.cms.urls")),
+)
+
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/scipy2014/settings.py
+++ b/scipy2014/settings.py
@@ -59,7 +59,7 @@ MEDIA_ROOT = os.path.join(PACKAGE_ROOT, "site_media", "media")
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
-MEDIA_URL = "/site_media/media/"
+MEDIA_URL = "/scipy2014/site_media/media/"
 
 # Absolute path to the directory that holds static files like app media.
 # Example: "/home/media/media.lawrence.com/apps/"
@@ -67,7 +67,7 @@ STATIC_ROOT = os.path.join(PACKAGE_ROOT, "site_media", "static")
 
 # URL that handles the static files like app media.
 # Example: "http://media.lawrence.com"
-STATIC_URL = "/site_media/static/"
+STATIC_URL = "/scipy2014/site_media/static/"
 
 # Additional directories which hold static files
 STATICFILES_DIRS = [

--- a/scipy2014/settings.py
+++ b/scipy2014/settings.py
@@ -195,7 +195,7 @@ AUTHENTICATION_BACKENDS = [
     "account.auth_backends.EmailAuthenticationBackend",
 ]
 
-LOGIN_URL = "/account/login/"  # @@@ any way this can be a url name?
+LOGIN_URL = "/scipy2014/account/login/"  # @@@ any way this can be a url name?
 
 EMAIL_CONFIRMATION_DAYS = 2
 EMAIL_DEBUG = DEBUG

--- a/scipy2014/urls.py
+++ b/scipy2014/urls.py
@@ -1,97 +1,12 @@
-from django.conf import settings
-from django.conf.urls.defaults import patterns, url, include
-from django.conf.urls.static import static
-
-from django.views.generic.simple import direct_to_template
-
+from django.conf.urls.defaults import patterns, include
 from django.contrib import admin
 admin.autodiscover()
-
-import symposion.views
 
 # from pinax.apps.account.openid_consumer import PinaxConsumer
 
 WIKI_SLUG = r"(([\w-]{2,})(/[\w-]{2,})*)"
 
 urlpatterns = patterns(
-    "",
-    url(r"^$",
-        direct_to_template,
-        {"template": "homepage.html"},
-        name="home"),
-    url(r"^about/$",
-        direct_to_template,
-        {"template": "about/about.html"},
-        name="about"),
-    url(r'^venue/$',
-        direct_to_template,
-        {'template': 'venue/venue.html'},
-        name='venue'),
-    url(r'^lodging/$',
-        direct_to_template,
-        {'template': 'venue/lodging.html'},
-        name='lodging'),
-    url(r'^directions/$',
-        direct_to_template,
-        {'template': 'venue/directions.html'},
-        name='directions'),
-    url(r'^floorplans/$',
-        direct_to_template,
-        {'template': 'venue/floorplans.html'},
-        name='floorplans'),
-    url(r'^restaurants/$',
-        direct_to_template,
-        {'template': 'venue/restaurants.html'},
-        name='restaurants'),
-    url(r'^plotting_contest/$',
-        direct_to_template,
-        {'template': 'about/plotting_contest.html'},
-        name='plotting_contest'),
-    url(r'^organizers/$',
-        direct_to_template,
-        {'template': 'about/organizers.html'},
-        name='organizers'),
-    url(r'^diversity/$',
-        direct_to_template,
-        {'template': 'about/diversity.html'},
-        name='diversity'),
-    url(r'^code_of_conduct/$',
-        direct_to_template,
-        {'template': 'about/code_of_conduct.html'},
-        name='code_of_conduct'),
-    url(r"^admin/", include(admin.site.urls)),
-    url(r'^video_highlights/$',
-        direct_to_template,
-        {'template': 'video_highlights.html'},
-        name='video highlights'),
-    url(r'^privacy_policy/$',
-        direct_to_template,
-        {'template': 'privacy_policy.html'},
-        name='privacy_policy'),
-    url(r'^sponsorship/$',
-        direct_to_template,
-        {'template': 'sponsorship.html'},
-        name='sponsorship'),
-
-    url(r"^account/signup/$",
-        symposion.views.SignupView.as_view(),
-        name="account_signup"),
-    url(r"^account/login/$",
-        symposion.views.LoginView.as_view(),
-        name="account_login"),
-    url(r"^account/", include("account.urls")),
-
-    url(r"^dashboard/", symposion.views.dashboard, name="dashboard"),
-    url(r"^speaker/", include("symposion.speakers.urls")),
-    url(r"^proposals/", include("symposion.proposals.urls")),
-    url(r"^sponsors/", include("symposion.sponsorship.urls")),
-    url(r"^boxes/", include("symposion.boxes.urls")),
-    url(r"^teams/", include("symposion.teams.urls")),
-    url(r"^reviews/", include("symposion.reviews.urls")),
-    url(r"^schedule/", include("symposion.schedule.urls")),
-    url(r"^markitup/", include("markitup.urls")),
-
-    url(r"^", include("symposion.cms.urls")),
+    '',
+    (r'^scipy2014/', include('scipy2014._urls')),
 )
-
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Moves site root to /scipy2014
Splits static & media locations into separate directories so that collectstatic doesn't clobber our sponsor's images
Install libjpeg and libtiff to so that pillow & easy_thumbnail work
