### PR TITLE
display title and speaker in the admin

### DIFF
--- a/scipy2014/proposals/admin.py
+++ b/scipy2014/proposals/admin.py
@@ -1,9 +1,33 @@
 from django.contrib import admin
 
+#from symposion.proposals.actions import export_as_csv_action
 from scipy2014.proposals.models import TalkPosterProposal, TutorialProposal, BofProposal, SprintProposal
 
+class TalkPosterProposalAdmin(admin.ModelAdmin):
+    model = TalkPosterProposal
+    list_display = ['title', 'speaker', 'topic_track', 'domain_symposium']
+    list_filter = ['submission_type', 'topic_track', 'domain_symposium']
+    """
+    actions = [export_as_csv_action("CSV Export", fields=[
+        "id",
+        "title",
+        "speaker",
+        "speaker_email",
+        "kind",
+    ])]
+    """
 
-admin.site.register(TalkPosterProposal)
-admin.site.register(TutorialProposal)
-admin.site.register(BofProposal)
-admin.site.register(SprintProposal)
+admin.site.register(TalkPosterProposal, TalkPosterProposalAdmin)
+admin.site.register(TutorialProposal,
+        list_display = ['title', 'speaker', 'track'],
+        list_filter = ['track'],
+        date_heirarchy='submitted',
+        )
+admin.site.register(BofProposal, 
+        list_display = ['title', 'speaker',],
+        date_heirarchy='submitted',
+        )
+admin.site.register(SprintProposal,
+        list_display = ['title', 'speaker',],
+        date_heirarchy='submitted',
+        )


### PR DESCRIPTION
This adds basic information to the admin view. It isn't profound, but it could be immediately helpful for people who need to interact with talks in the admin.

![adminview](https://cloud.githubusercontent.com/assets/529748/2559972/1bdc1bc4-b79a-11e3-89d1-15d95b84959d.png)
