### PR TITLE
Add information about tracks and domain in review dashboards

### DIFF
--- a/scipy2014/proposals/models.py
+++ b/scipy2014/proposals/models.py
@@ -27,6 +27,7 @@ class TalkPosterProposal(ProposalBase):
         (TRACK_EDUCATION, 'Scientific Computing Education'),
         (TRACK_GIS, 'Geospatial Data in Science'),
     ]
+    track_lookup = dict(TOPIC_TRACKS)
 
     DOMAIN_NONE = 1
     DOMAIN_MEDICAL_IMAGING = 2
@@ -48,10 +49,17 @@ class TalkPosterProposal(ProposalBase):
         (DOMAIN_ENGINEERING, 'Engineering'),
         (DOMAIN_SOCIAL_SCIENCES_AND_HUMANITIES, 'Computational Social Sciences and Digital Humanities'),
     ]
+    domain_lookup = dict(DOMAIN_SYMPOSIA)
 
     submission_type = models.IntegerField(choices=SUBMISSION_TYPES, default=1)
     topic_track = models.IntegerField(choices=TOPIC_TRACKS, default=1)
     domain_symposium = models.IntegerField(choices=DOMAIN_SYMPOSIA, default=1)
+
+    def topic_track_display(self):
+        return self.track_lookup.get(self.topic_track, '')
+    def domain_symposium_display(self):
+        return self.domain_lookup.get(self.domain_symposium, '')
+
 
     class Meta:
         verbose_name = "talk/poster proposal"
@@ -68,6 +76,7 @@ class TutorialProposal(ProposalBase):
         (TRACK_INTERMEDIATE, "Intermediate"),
         (TRACK_ADVANCED, "Advanced"),
     ]
+    track_lookup = dict(TRACKS)
 
     track = models.IntegerField(choices=TRACKS)
 
@@ -80,6 +89,9 @@ links to installation documentation should be provided for packages
 that are not available through easy_install, pip, Canopy, Anaconda
 etc., or that require third party libraries."""
     )
+
+    def track_display(self):
+        return self.track_lookup.get(self.track, '')
 
     class Meta:
         verbose_name = "tutorial proposal"

--- a/scipy2014/templates/proposals/_proposal_fields.html
+++ b/scipy2014/templates/proposals/_proposal_fields.html
@@ -1,0 +1,63 @@
+{% load i18n %}
+
+<dl class="dl-horizontal">
+    <dt>{% trans "Submitted by" %}</dt>
+    <dd>{{ proposal.speaker }}</dd>
+    
+    <dt>{% trans "Track" %}</dt>
+    <dd>{{ proposal.get_topic_track_display }}&nbsp;</dd>
+    
+    <dt>{% trans "Audience Level" %}</dt>
+    <dd>{{ proposal.get_audience_level_display }}&nbsp;</dd>
+    
+    <dt>{% trans "Domain Symposium" %}</dt>
+    <dd>{{ proposal.get_domain_symposium_display }}&nbsp;</dd>
+
+    {% if proposal.additional_speakers.all %}
+        <dt>{% trans "Additional Speakers" %}</dt>
+        <dd>
+            {% for speaker in proposal.additional_speakers.all %}
+                <li>
+                    {% if speaker.user %}
+                        <strong>{{ speaker.name }}</strong> &lt;{{ speaker.email }}&gt;
+                    {% else %}
+                        {{ speaker.email }} ({% trans "Invitation Sent" %})
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </dd>
+    {% endif %}
+    
+    <dt>{% trans "Description" %}</dt>
+    <dd>{{ proposal.description }}&nbsp;</dd>
+    
+    <dt>{% trans "Abstract" %}</dt>
+    <dd>{{ proposal.abstract|safe }}&nbsp;</dd>
+    
+    <dt>{% trans "Notes" %}</dt>
+    <dd>{{ proposal.additional_notes|safe }}&nbsp;</dd>
+    
+    <dt>{% trans "Speaker Bio" %}</dt>
+    <dd>{{ proposal.speaker.biography|safe }}&nbsp;</dd>
+    
+    <dt>{% trans "Documents" %}</dt>
+    <dd>
+        {% if proposal.supporting_documents.exists %}
+            <table class="table table-striped">
+                {% for document in proposal.supporting_documents.all %}
+                    <tr>
+                        <td><a href="{{ document.download_url }}">{{ document.description }}</a></td>
+                        <td>
+                        <form style="margin: 0;" method="post" action="{% url proposal_document_delete document.pk %}">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-mini">delete</button>
+                        </form>
+                    </td>
+                    </tr>
+                {% endfor %}
+            </table>
+        {% else %}
+            No supporting documents attached to this proposal.
+        {% endif %}
+    </dd>
+</dl>

--- a/scipy2014/templates/reviews/_review_table.html
+++ b/scipy2014/templates/reviews/_review_table.html
@@ -4,7 +4,8 @@
     <thead>
         <th>#</th>
         <th>{% trans "Speaker / Title" %}</th>
-        <th>{% trans "Category / Domain" %}</th>
+        <th>{% trans "Category" %}</th>
+        <th>{% trans "Domain" %}</th>
         <th><i class="icon-comment-alt"></i></th>
         <th>{% trans "+1" %}</th>
         <th>{% trans "+0" %}</th>
@@ -27,6 +28,8 @@
                 <td>
                   {{ proposal.topic_track_display }}
                   {{ proposal.track_display }}
+                </td>
+                <td>
                   {{ proposal.domain_symposium_display }}
                 </td>
                 <td>{{ proposal.comment_count }}</td>

--- a/scipy2014/templates/reviews/_review_table.html
+++ b/scipy2014/templates/reviews/_review_table.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+
+<table class="table table-striped table-bordered table-reviews">
+    <thead>
+        <th>#</th>
+        <th>{% trans "Speaker / Title" %}</th>
+        <th>{% trans "Category / Domain" %}</th>
+        <th><i class="icon-comment-alt"></i></th>
+        <th>{% trans "+1" %}</th>
+        <th>{% trans "+0" %}</th>
+        <th>{% trans "-0" %}</th>
+        <th>{% trans "-1" %}</th>
+        <th><a href="#" class="tip" title="{% trans "Your Rating" %}"><i class="icon-user"></i></a></th>
+    </thead>
+    
+    <tbody>
+        {% for proposal in proposals %}
+            <tr class="{{ proposal.user_vote_css }}">
+                <td>{{ proposal.number }}</td>
+                <td>
+                    <a href="{% url review_detail proposal.pk %}">
+                        <small><strong>{{ proposal.speaker }}</strong></small>
+                        <br />
+                        {{ proposal.title }}
+                    </a>
+                </td>
+                <td>
+                  {{ proposal.topic_track_display }}
+                  {{ proposal.track_display }}
+                  {{ proposal.domain_symposium_display }}
+                </td>
+                <td>{{ proposal.comment_count }}</td>
+                <td>{{ proposal.plus_one }}</td>
+                <td>{{ proposal.plus_zero }}</td>
+                <td>{{ proposal.minus_zero }}</td>
+                <td>{{ proposal.minus_one }}</td>
+                <td>{{ proposal.user_vote|default:"" }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
This adds the track info as requested in #54 

result resembles the following

![reviewlist](https://cloud.githubusercontent.com/assets/529748/2575131/aa78366a-b948-11e3-8bc4-d6e7f45a4b82.png)
