### PR TITLE
update deadline text in header for all of the pages

### DIFF
--- a/scipy2014/templates/site_base.html
+++ b/scipy2014/templates/site_base.html
@@ -61,10 +61,8 @@
 
               <div class="header_tagline">Scientific Computing with Python <br /> Austin, Texas &#8226; July 6-12
               <br />
-              <span class="highlight" style="font-family: Arial, non-serif; padding: 0 4em 0 4em;"><em>Abstract submission deadline: April 1st</em></span>
-              <br />
-              <span class="highlight" style="font-family: Arial, non-serif; padding: 0 4em 0 4em;"><em>Financial aid application deadline: April 7th</em></span>
-                    </div>
+              <span class="highlight" style="font-family: Arial, non-serif; padding: 0.15em 4em;"><em>Early Bird Registration Deadline: May 6th or first 300</em></span>
+            </div>
         </header>
         <div class="navbar">
             <div class="navbar-inner">


### PR DESCRIPTION
The abstract and financial aid alerts were still showing on some of the headers. This fixes that.
