### PR TITLE
Subtypes

### DIFF
--- a/scipy2014/proposals/models.py
+++ b/scipy2014/proposals/models.py
@@ -61,7 +61,7 @@ class TalkPosterProposal(ProposalBase):
     def domain_symposium_display(self):
         return self.domain_lookup.get(self.domain_symposium, '')
     def submission_type_display(self):
-        return self.submission_type_lookup.get(self.domain_symposium, '')
+        return self.submission_type_lookup.get(self.submission_type, '')
 
 
     class Meta:

--- a/scipy2014/proposals/models.py
+++ b/scipy2014/proposals/models.py
@@ -14,6 +14,7 @@ class TalkPosterProposal(ProposalBase):
         (TYPE_TALK_ONLY, "Talk Only"),
         (TYPE_POSTER_ONLY, "Poster Only"),
     ]
+    submission_type_lookup = dict(SUBMISSION_TYPES)
 
     TRACK_GENERAL = 1
     TRACK_MACHINE_LEARNING = 2
@@ -59,6 +60,8 @@ class TalkPosterProposal(ProposalBase):
         return self.track_lookup.get(self.topic_track, '')
     def domain_symposium_display(self):
         return self.domain_lookup.get(self.domain_symposium, '')
+    def submission_type_display(self):
+        return self.submission_type_lookup.get(self.domain_symposium, '')
 
 
     class Meta:

--- a/scipy2014/templates/proposals/_proposal_fields.html
+++ b/scipy2014/templates/proposals/_proposal_fields.html
@@ -13,6 +13,9 @@
     <dt>{% trans "Domain Symposium" %}</dt>
     <dd>{{ proposal.get_domain_symposium_display }}&nbsp;</dd>
 
+    <dt>{% trans "Submission Type" %}</dt>
+    <dd>{{ proposal.get_submission_type_display }}&nbsp;</dd>
+
     {% if proposal.additional_speakers.all %}
         <dt>{% trans "Additional Speakers" %}</dt>
         <dd>

--- a/scipy2014/templates/reviews/_review_table.html
+++ b/scipy2014/templates/reviews/_review_table.html
@@ -6,6 +6,7 @@
         <th>{% trans "Speaker / Title" %}</th>
         <th>{% trans "Category" %}</th>
         <th>{% trans "Domain" %}</th>
+        <th>{% trans "Type" %}</th>
         <th><i class="icon-comment-alt"></i></th>
         <th>{% trans "+1" %}</th>
         <th>{% trans "+0" %}</th>
@@ -31,6 +32,9 @@
                 </td>
                 <td>
                   {{ proposal.domain_symposium_display }}
+                </td>
+                <td>
+                  {{ proposal.submission_type_display }}
                 </td>
                 <td>{{ proposal.comment_count }}</td>
                 <td>{{ proposal.plus_one }}</td>


### PR DESCRIPTION
Hi there (mostly @codersquid). I'm trying to address this issue I have : https://github.com/scipy-conference/SciPy-2014/issues/107

It's so similar to a previous issue, that I just made changes as analogous as possible to the pull request that closed the previous issue (https://github.com/scipy-conference/SciPy-2014/pull/101/files)

The idea is to make the review dashboard show the submission type (Poster Only, Talk Only, Poster Or Talk). 

I have absolutely no idea what I'm doing and can't build the site to check if it works... so... review with caution?
