### PR TITLE
Schedule changes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "../symposion", "/symposion"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/data/rooms.csv
+++ b/data/rooms.csv
@@ -1,0 +1,19 @@
+section_slug,name,order
+talks-posters,Grand Ballroom,0
+talks-posters,Room 203,1
+talks-posters,Room 204,2
+tutorials,Room 101,0
+tutorials,Room 102,1
+tutorials,Room 105,2
+tutorials,Room 106,3
+bofs,Grand Ballroom,0
+bofs,Room 203,1
+bofs,Room 204,2
+bofs,Room 110,3
+bofs,Room 111,4
+bofs,Room 112,5
+sprints,Room 103,0
+sprints,Room 104,1
+sprints,Room 107,2
+sprints,Room 108,3
+sprints,Room 202,4

--- a/data/slotkinds.csv
+++ b/data/slotkinds.csv
@@ -1,0 +1,20 @@
+section_slug,slot_kind,presentation_menu
+talks-posters,Astronomy and Astrophysics Symposium,TRUE
+talks-posters,Bioinformatics Symposium,TRUE
+talks-posters,Break,FALSE
+talks-posters,Breakfast,FALSE
+talks-posters,Digital Social Sciences Symposium,TRUE
+talks-posters,Engineering Symposium,TRUE
+talks-posters,General,TRUE
+talks-posters,Geophysics Symposium,TRUE
+talks-posters,Geospatial Data in Science,TRUE
+talks-posters,Imaging and Vision Symposium,TRUE
+talks-posters,Job Fair,FALSE
+talks-posters,Keynote,FALSE
+talks-posters,Lightning Talks,FALSE
+talks-posters,Lunch,FALSE
+talks-posters,Posters,FALSE
+talks-posters,Scientific Computing in Education,TRUE
+talks-posters,Setup,FALSE
+talks-posters,Welcome,FALSE
+talks-posters,BOFs,FALSE

--- a/data/talksposters.csv
+++ b/data/talksposters.csv
@@ -1,0 +1,156 @@
+date,time_start,time_end,kind,room,proposal_id,description
+7/8/2014,7:30,8:30,Breakfast,Grand Ballroom,,Sponsor Breakfast (Room 301)
+7/8/2014,7:30,8:30,Breakfast,Room 203,,
+7/8/2014,7:30,8:30,Breakfast,Room 204,,
+7/8/2014,8:30,9:00,Break,Grand Ballroom,,Morning Break (GB Hallway)
+7/8/2014,8:30,9:00,Break,Room 203,,Morning Break (GB Hallway)
+7/8/2014,8:30,9:00,Break,Room 204,,Morning Break (GB Hallway)
+7/8/2014,10:00,10:15,Break,Grand Ballroom,,Break (GB Hallway)
+7/8/2014,10:00,10:15,Break,Room 203,,
+7/8/2014,10:00,10:15,Break,Room 204,,
+7/8/2014,15:15,15:30,Break,Grand Ballroom,,Break (GB Hallway)
+7/8/2014,15:15,15:30,Break,Room 203,,
+7/8/2014,15:15,15:30,Break,Room 204,,
+7/8/2014,7:00,7:30,Setup,Grand Ballroom,,Set-up
+7/8/2014,7:00,7:30,Setup,Room 203,,Set-up
+7/8/2014,7:00,7:30,Setup,Room 204,,Set-up
+7/8/2014,9:00,9:15,Welcome,Grand Ballroom,,Welcome
+7/8/2014,9:00,9:15,Welcome,Room 203,,Welcome
+7/8/2014,9:00,9:15,Welcome,Room 204,,Welcome
+7/8/2014,9:15,10:00,Keynote,Grand Ballroom,,Keynote
+7/8/2014,9:15,10:00,Keynote,Room 203,,Keynote
+7/8/2014,9:15,10:00,Keynote,Room 204,,Keynote
+7/8/2014,12:15,13:30,Lunch,Grand Ballroom,,Lunch
+7/8/2014,12:15,13:30,Lunch,Room 203,,
+7/8/2014,12:15,13:30,Lunch,Room 204,,
+7/8/2014,15:00,15:15,Setup,Grand Ballroom,,Poster Set-Up (Ballroom)
+7/8/2014,15:00,15:15,Setup,Room 203,,Poster Set-Up (Ballroom)
+7/8/2014,15:00,15:15,Setup,Room 204,,Poster Set-Up (Ballroom)
+7/8/2014,16:30,19:00,Lightning Talks,Grand Ballroom,,Lightning Talks
+7/8/2014,16:30,19:00,Lightning Talks,Room 203,,Lightning Talks
+7/8/2014,16:30,19:00,Lightning Talks,Room 204,,Lightning Talks
+7/8/2014,19:00,21:00,Job Fair,Grand Ballroom,,
+7/8/2014,19:00,21:00,Job Fair,Room 203,,
+7/8/2014,19:00,21:00,Job Fair,Room 204,,
+7/9/2014,7:00,8:00,Setup,Grand Ballroom,,Set-up
+7/9/2014,7:00,8:00,Setup,Room 203,,Set-up
+7/9/2014,7:00,8:00,Setup,Room 204,,Set-up
+7/9/2014,8:00,9:00,Break,Grand Ballroom,,Morning Break (GB Hallway)
+7/9/2014,8:00,9:00,Break,Room 203,,Morning Break (GB Hallway)
+7/9/2014,8:00,9:00,Break,Room 204,,Morning Break (GB Hallway)
+7/9/2014,9:00,9:15,Welcome,Grand Ballroom,,Welcome
+7/9/2014,9:00,9:15,Welcome,Room 203,,Welcome
+7/9/2014,9:00,9:15,Welcome,Room 204,,Welcome
+7/9/2014,9:15,10:00,Keynote,Grand Ballroom,,Keynote
+7/9/2014,9:15,10:00,Keynote,Room 203,,Keynote
+7/9/2014,9:15,10:00,Keynote,Room 204,,Keynote
+7/9/2014,10:00,10:15,Break,Grand Ballroom,,Break (GB Hallway)
+7/9/2014,10:00,10:15,Break,Room 203,,
+7/9/2014,10:00,10:15,Break,Room 204,,
+7/9/2014,12:15,13:30,Lunch,Grand Ballroom,,Lunch
+7/9/2014,12:15,13:30,Lunch,Room 203,,Lunch
+7/9/2014,12:15,13:30,Lunch,Room 204,,Lunch
+7/9/2014,14:30,15:30,Posters,Grand Ballroom,,
+7/9/2014,14:30,15:30,Posters,Room 203,,
+7/9/2014,14:30,15:30,Posters,Room 204,,
+7/9/2014,16:30,19:00,Lightning Talks,Grand Ballroom,,Lightning Talks
+7/9/2014,16:30,19:00,Lightning Talks,Room 203,,Lightning Talks
+7/9/2014,16:30,19:00,Lightning Talks,Room 204,,Lightning Talks
+7/10/2014,9:00,9:15,Welcome,Grand Ballroom,,Welcome
+7/10/2014,9:00,9:15,Welcome,Room 203,,Welcome
+7/10/2014,9:00,9:15,Welcome,Room 204,,Welcome
+7/10/2014,9:15,10:00,Keynote,Grand Ballroom,,Keynote
+7/10/2014,9:15,10:00,Keynote,Room 203,,Keynote
+7/10/2014,9:15,10:00,Keynote,Room 204,,Keynote
+7/10/2014,12:00,12:15,Break,Grand Ballroom,,
+7/10/2014,12:00,12:15,Break,Room 203,,
+7/10/2014,12:00,12:15,Break,Room 204,,
+7/10/2014,12:15,13:30,Lunch,Grand Ballroom,,
+7/10/2014,12:15,13:30,Lunch,Room 203,,
+7/10/2014,12:15,13:30,Lunch,Room 204,,
+7/10/2014,13:30,14:15,BOFs,Grand Ballroom,,
+7/10/2014,13:30,14:15,BOFs,Room 203,,
+7/10/2014,13:30,14:15,BOFs,Room 204,,
+7/10/2014,15:00,15:30,Break,Grand Ballroom,,
+7/10/2014,15:00,15:30,Break,Room 203,,
+7/10/2014,15:15,15:30,Break,Room 203,,
+7/10/2014,16:30,19:00,Lightning Talks,Grand Ballroom,,
+7/10/2014,16:30,19:00,Lightning Talks,Room 203,,
+7/10/2014,16:30,19:00,Lightning Talks,Room 204,,
+7/8/2014,10:15,10:45,Scientific Computing in Education,Grand Ballroom,88,
+7/8/2014,10:15,10:45,Geospatial Data in Science,Room 203,176,
+7/8/2014,10:15,10:45,General,Room 204,128,
+7/8/2014,10:45,11:15,Scientific Computing in Education,Grand Ballroom,177,
+7/8/2014,10:45,11:15,Geospatial Data in Science,Room 203,106,
+7/8/2014,10:45,11:15,General,Room 204,130,
+7/8/2014,11:15,11:45,Scientific Computing in Education,Grand Ballroom,98,
+7/8/2014,11:15,11:45,Geospatial Data in Science,Room 203,104,
+7/8/2014,11:15,11:45,General,Room 204,14,
+7/8/2014,11:45,12:00,Scientific Computing in Education,Grand Ballroom,37,
+7/8/2014,11:45,12:00,Geospatial Data in Science,Room 203,135,
+7/8/2014,11:45,12:00,General,Room 204,33,
+7/8/2014,14:15,14:45,Scientific Computing in Education,Grand Ballroom,149,
+7/8/2014,14:15,14:45,Geospatial Data in Science,Room 203,160,
+7/8/2014,14:15,14:45,General,Room 204,110,
+7/8/2014,14:45,15:00,Scientific Computing in Education,Grand Ballroom,185,
+7/8/2014,14:45,15:00,Geospatial Data in Science,Room 203,57,
+7/8/2014,14:45,15:00,General,Room 204,116,
+7/8/2014,15:30,16:00,Scientific Computing in Education,Grand Ballroom,15,
+7/8/2014,15:30,16:00,Geospatial Data in Science,Room 203,80,
+7/8/2014,15:30,16:00,General,Room 204,7,
+7/8/2014,16:00,16:15,Scientific Computing in Education,Grand Ballroom,13,
+7/8/2014,16:00,16:15,Geospatial Data in Science,Room 203,103,
+7/8/2014,16:00,16:30,General,Room 204,153,
+7/9/2014,10:15,10:45,Scientific Computing in Education,Grand Ballroom,156,
+7/9/2014,10:15,10:45,Geospatial Data in Science,Room 203,131,
+7/9/2014,10:15,10:45,General,Room 204,141,
+7/9/2014,10:45,11:15,Scientific Computing in Education,Grand Ballroom,169,
+7/9/2014,10:45,11:15,Geospatial Data in Science,Room 203,28,
+7/9/2014,10:45,11:15,General,Room 204,67,
+7/9/2014,11:15,11:45,Scientific Computing in Education,Grand Ballroom,82,
+7/9/2014,11:15,11:45,Geospatial Data in Science,Room 203,179,
+7/9/2014,11:15,11:45,General,Room 204,38,
+7/9/2014,11:45,12:00,Scientific Computing in Education,Grand Ballroom,114,
+7/9/2014,11:45,12:00,Geospatial Data in Science,Room 203,184,
+7/9/2014,11:45,12:00,General,Room 204,108,
+7/10/2014,10:15,10:45,Scientific Computing in Education,Grand Ballroom,,
+7/10/2014,10:15,10:45,Geospatial Data in Science,Room 203,,
+7/10/2014,10:15,10:45,General,Room 204,,
+7/10/2014,10:45,11:15,Scientific Computing in Education,Grand Ballroom,,
+7/10/2014,10:45,11:15,Geospatial Data in Science,Room 203,,
+7/10/2014,10:45,11:15,General,Room 204,,
+7/10/2014,11:15,11:45,Scientific Computing in Education,Grand Ballroom,,
+7/10/2014,11:15,11:45,Geospatial Data in Science,Room 203,,
+7/10/2014,11:15,11:45,General,Room 204,,
+7/10/2014,11:45,12:00,Scientific Computing in Education,Grand Ballroom,,
+7/10/2014,11:45,12:00,Geospatial Data in Science,Room 203,,
+7/10/2014,11:45,12:00,General,Room 204,,
+7/9/2014,13:30,14:00,Bioinformatics Symposium,Grand Ballroom,175,
+7/9/2014,14:00,14:15,Bioinformatics Symposium,Grand Ballroom,24,
+7/9/2014,15:30,16:00,Bioinformatics Symposium,Grand Ballroom,94,
+7/9/2014,16:00,16:30,Bioinformatics Symposium,Grand Ballroom,36,
+7/9/2014,13:30,13:50,Astronomy and Astrophysics Symposium,Room 203,101,
+7/9/2014,13:50,14:10,Astronomy and Astrophysics Symposium,Room 203,26,
+7/9/2014,14:10,14:30,Astronomy and Astrophysics Symposium,Room 203,66,
+7/9/2014,15:30,15:50,Astronomy and Astrophysics Symposium,Room 203,39,
+7/9/2014,15:50,16:10,Astronomy and Astrophysics Symposium,Room 203,81,
+7/9/2014,16:10,16:30,Astronomy and Astrophysics Symposium,Room 203,161,
+7/9/2014,13:30,14:00,Geophysics Symposium,Room 204,86,
+7/9/2014,14:00,14:30,Geophysics Symposium,Room 204,122,
+7/9/2014,15:30,16:00,Geophysics Symposium,Room 204,60,
+7/9/2014,16:00,16:30,Geophysics Symposium,Room 204,27,
+7/10/2014,14:15,14:30,Imaging and Vision Symposium,Room 204,85,
+7/10/2014,14:30,14:45,Imaging and Vision Symposium,Room 204,183,
+7/10/2014,14:45,15:00,Imaging and Vision Symposium,Room 204,84,
+7/10/2014,15:00,15:15,Imaging and Vision Symposium,Room 204,50,
+7/10/2014,15:30,15:45,Imaging and Vision Symposium,Room 204,166,
+7/10/2014,15:45,16:00,Imaging and Vision Symposium,Room 204,45,
+7/10/2014,16:00,16:15,Imaging and Vision Symposium,Room 204,46,
+7/10/2014,14:15,14:45,Engineering Symposium,Grand Ballroom,11,
+7/10/2014,14:45,15:00,Engineering Symposium,Grand Ballroom,42,
+7/10/2014,15:30,16:00,Engineering Symposium,Grand Ballroom,74,
+7/10/2014,16:00,16:30,Engineering Symposium,Grand Ballroom,157,
+7/10/2014,14:15,14:45,Digital Social Sciences Symposium,Room 203,189,
+7/10/2014,14:45,15:00,Digital Social Sciences Symposium,Room 203,182,
+7/10/2014,15:30,16:00,Digital Social Sciences Symposium,Room 203,145,
+7/10/2014,16:00,16:30,Digital Social Sciences Symposium,Room 203,190,

--- a/fabfile.py
+++ b/fabfile.py
@@ -67,6 +67,7 @@ def vagrant():
     env.update({
         'site': 'localhost',
         'upstream': 'localhost',
+        'rewrite_name': 'citationsneeded.org',
         'available': 'conference',
         'ssl_cert': '/etc/ssl/localcerts/conference.scipy.org.crt',
         'ssl_key': '/etc/ssl/private/conference.scipy.org.key',

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 Django==1.4.12
 django-user-accounts==1.0b7
 #symposion==1.0b1.dev54
--e git+https://github.com/scipy-conference/symposion.git@0.0.4-reviewadmin#egg=symposion
+-e git+https://github.com/scipy-conference/symposion.git@0.0.5-scipy2014#egg=symposion
 pinax-theme-bootstrap==3.0a4
 django-forms-bootstrap==2.0.3.post1
 metron==1.3


### PR DESCRIPTION
This picks up a symposion change from the pyconca symposion branch that should help with staggered schedule display for #127. I've also checked csv files since maintaining htem in google docs is one of the most annoying things ever.

Once this is ready to go, I'll need to do 
`alter table schedule_slotkind add presentation bool not null default 1;`
on the db.

I've done this on staging already and regenerated the grid. example: https://citationsneeded.org/scipy2014/schedule/talks-posters/
