### PR TITLE
Accepted talks cleanup

### DIFF
--- a/scipy2014/templates/participate/presentations.html
+++ b/scipy2014/templates/participate/presentations.html
@@ -14,138 +14,35 @@
 
 {% box "presentation-guidelines" %}
 
-<h2>List of Accepted Presentations</h2>
-<table class="table table-striped">
-  <thead>
-    <th>Title</th>
-    <th>Presenter</th>
-    <th>Track</th>
-   </thead>
-   <tbody>
- <tr><td>airspeed velocity: tracking performance of Python projects over their lifetime</td><td>Michael Droettboom</td><td>gen2</td></tr>
-<tr><td> Neural Networks for Computer Vision</td><td>Kyle Kastner</td><td>viz</td></tr>
-<tr><td>  A success story in using Python in a graduate chemical engineering course</td><td>John Kitchin</td><td>eng</td></tr>
- <tr><td>Scientific Computing in the Undergraduate Meteorology Curriculum at Millersville University</td><td>Alex DeCaria</td><td>edu2</td></tr>
- <tr><td>SociaLite: Python-integrated query language for data analysis</td><td>Jiwon Seo</td><td>poster</td></tr>
- <tr><td>Zeke: A Python Platform for Teaching Mathematical Modeling of Infectious Diseases</td><td>Eric Lofgren</td><td>edu2</td></tr>
- <tr><td>PySIMS: A Python library for ToF-SIMS analysis</td><td>Bob Moision</td><td>poster</td></tr>
- <tr><td>Investigating Stiffness Controls on Earthquake Behavior. An Ideal Environment for Python Workflows</td><td>John Leeman</td><td>poster</td></tr>
- <tr><td>The KBase Narrative: Bioinformatics for the 99%</td><td>Stephen Chan</td><td>bioinfo</td></tr>
- <tr><td>Enhancements to Ginga: an Astronomical Image Viewer and Toolkit</td><td>Eric Jeschke</td><td>astro</td></tr>
- <tr><td>Prototyping a Geophysical Algorithm in Python</td><td>Karl Schleicher</td><td>geo</td></tr>
- <tr><td>Rasterio: Geospatial Raster Data Access for Programmers and Future Programmers</td><td>Sean Gillies</td><td>gis1</td></tr>
- <tr><td>Python cross-compilation and platform builds for HPC and scientific computing</td><td>Jean-Christophe Fillion-Robin</td><td>poster</td></tr>
- <tr><td>youre doing it wrong: the lack of reproducibility in statistical science and how to fix it</td><td>Michael McKerns</td><td>poster</td></tr>
- <tr><td>the failure of python object serialization: why HPC in python is broken and how to fix it</td><td>Michael McKerns</td><td>gen1</td></tr>
- <tr><td>Clustering of high-content screen images to discover off-target phenotypes</td><td>Juan Nunez-Iglesias</td><td>bioinfo</td></tr>
- <tr><td>Practical experience in teaching numerical methods with IPython notebooks</td><td>David I. Ketcheson</td><td>edu1</td></tr>
- <tr><td>Bokeh: Interactive Visualizations in the Browser</td><td>Bryan  Van de Ven</td><td>gen3</td></tr>
- <tr><td>Astropy in 2014; Whats new where we are headed</td><td>Perry Greenfield</td><td>astro</td></tr>
- <tr><td>Synthesis and analysis of circuits in the IPython notebook</td><td>Nikolas Tezak</td><td>eng</td></tr>
- <tr><td>perprof-py -- A Python Package for Performance Profiling</td><td>Raniere Silva</td><td>poster</td></tr>
- <tr><td>Perceptions of Matplotlib colormaps</td><td>Kristen M. Thyng</td><td>viz</td></tr>
- <tr><td>How to choose a good colour map</td><td>Damon McDougall</td><td>viz</td></tr>
- <tr><td>TracPy: Wrapping the FORTRAN Lagrangian trajectory model TRACMASS</td><td>Kristen M. Thyng</td><td>gis4</td></tr>
- <tr><td>Visualization of emerging zoonoses through temporal networks</td><td>Caitlin Rivers</td><td>viz</td></tr>
- <tr><td>A Python Framework for 3D Gamma Ray Imaging</td><td>Ross Barnowski</td><td>gen4</td></tr>
- <tr><td>SimPEG: A framework for Simulation and Parameter Estimation in Geophysics</td><td>Rowan Cockett</td><td>poster</td></tr>
- <tr><td>Climate & GIS: User friendly data access; workflows; manipulation; analysis and visualization of cli</td><td>Aashish Chaudhary</td><td>gis2</td></tr>
- <tr><td>Web-based Analysis and Visualization for Large Geospatial Datasets for Climate Scientists</td><td>Aashish Chaudhary</td><td>poster</td></tr>
- <tr><td>PyGECoRe: Geometrically Exact Conservative Remapping tool for any grids in spherical geometry</td><td>Ki-Hwan Kim</td><td>poster</td></tr>
- <tr><td>The history and design behind the Python Geophysical Modelling and Interpretation (PyGMI) package</td><td>Patrick Cole</td><td>geo</td></tr>
- <tr><td>Static Compilation of High Level Idioms</td><td>Serge Guelton</td><td>poster</td></tr>
- <tr><td>Python based pipeline for calibration and post-processing in Astronomical High-Contrast Imaging</td><td>Carlos Alberto Gomez Gonzalez</td><td>poster</td></tr>
- <tr><td>Having your big-array cake and eating it.</td><td>Richard Hattersley</td><td>poster</td></tr>
- <tr><td>Zero Dependency Python</td><td>Matthew Turk</td><td>gen4</td></tr>
- <tr><td>Simulating X-ray Observations with Python</td><td>John ZuHone</td><td>astro</td></tr>
- <tr><td>Object-oriented programming with NumPy using CPython & PyPy; comparison with C++ & modern Fortran</td><td>Dorota Jarecka</td><td>gen3</td></tr>
- <tr><td>SunPy: One More Trip Around the Sun</td><td>Stuart Mumford</td><td>astro</td></tr>
- <tr><td>Dedalus: a Python-based Spectral PDE Solver</td><td>Keaton J. Burns</td><td>poster</td></tr>
- <tr><td>Validated numerics in Python</td><td>David P. Sanders</td><td>poster</td></tr>
- <tr><td>CodaLab: a new service for data exchange code execution benchmarks and reproducible research</td><td>Evelyne Viegas</td><td>eng</td></tr>
- <tr><td>The ANSS Comprehensive Earthquake Catalog and Tools</td><td>Mike Hearne</td><td>poster</td></tr>
- <tr><td>Python Coding of Geospatial Processing in Web-based Mapping Applications</td><td>Michael Nowak</td><td>poster</td></tr>
- <tr><td>Using Python to unlock the heating of the solar corona</td><td>Stuart Mumford</td><td>poster</td></tr>
- <tr><td>Cartopy</td><td>Richard Hattersley</td><td>gis2</td></tr>
- <tr><td>yt: volumetric data analysis</td><td>Nathan Goldbaum</td><td>poster</td></tr>
- <tr><td>Behind the Scenes of the University and Supplier Relationship</td><td>Alexis Perez</td><td>poster</td></tr>
- <tr><td>Multi-Purpose Particle Tracking</td><td>Daniel B. Allan</td><td>viz</td></tr>
- <tr><td>SimpleITK - Advanced Image Analysis for Python</td><td>Bradley Lowekamp</td><td>viz</td></tr>
- <tr><td>The road to Modelr: building a commercial web application on an open source foundation</td><td>Matt Hall</td><td>geo</td></tr>
- <tr><td>hyperopt-sklearn: A hyperparameter optimization framework for scikit-learn</td><td>Brent Komer</td><td>poster</td></tr>
- <tr><td>Frequentism and Bayesianim: Whats the Big Deal?</td><td>Jake VanderPlas</td><td>edu1</td></tr>
- <tr><td>Time Series Analysis for Network Security</td><td>Phil Roth</td><td>gen4</td></tr>
- <tr><td>IPython-Reveal.js attacks again but now... it is alive!</td><td>Damian Avila</td><td>edu4</td></tr>
- <tr><td>Using Fatiando a Terra to solve inverse problems in geophysics</td><td>Leonardo Uieda</td><td>poster</td></tr>
- <tr><td>Building petabyte-scale comparative genomics pipelines</td><td>Chris Cope</td><td>bioinfo</td></tr>
- <tr><td>putting the v in IPython: vim-ipython and ipython-vimception</td><td>Paul Ivanov</td><td>poster</td></tr>
- <tr><td>Measuring rainshafts: Bringing python to bear on remote sensing data.</td><td>Scott Collis</td><td>gis4</td></tr>
- <tr><td>Project-based introduction to scientific computing for physics majors</td><td>Jennifer Klay</td><td>edu1</td></tr>
- <tr><td>Software for Panoptes:  A Citizen Science Observatory</td><td>Josh Walawender</td><td>astro</td></tr>
- <tr><td>Ocean Model Assessment for Everyone</td><td>Richard Signell</td><td>gis2</td></tr>
- <tr><td>The PlaceIQ Location-Based Analytic Platform:</td><td>Eliza Chang</td><td>gis1</td></tr>
- <tr><td>Blaze: Building a Foundation for Array-Oriented Computing in Python</td><td>Mark Wiebe</td><td>gen4</td></tr>
- <tr><td>Fast Algorithms for Binary Spatial Adjacency Measures</td><td>Jason Laura</td><td>gis3</td></tr>
- <tr><td>SymPy: Symbolic math for Python</td><td>Aaron Meurer</td><td>poster</td></tr>
- <tr><td>Conda: a cross-platform package manager for any binary distribution</td><td>Aaron Meurer</td><td>gen3</td></tr>
- <tr><td>WCSAxes: a framework for plotting astronomical data</td><td>Thomas Robitaille</td><td>gen2</td></tr>
- <tr><td>Towards a better documentation system for Scientific Python</td><td>Carlos Cordoba</td><td>edu3</td></tr>
- <tr><td>In with the old In with the new: Matplotlbs role in a D3js world</td><td>Jake VanderPlas</td><td>poster</td></tr>
- <tr><td>The Berkeley Institute for Data Science: a place for people like us</td><td>Fernando Perez</td><td>edu3</td></tr>
- <tr><td>PyViennaCL: Very easy GPGPU linear algebra</td><td>Toby St Clere Smithe</td><td>gen2</td></tr>
- <tr><td>Scientific Knowledge Management with Web of Trails</td><td>Jon Riehl</td><td>poster</td></tr>
- <tr><td>Keeping Scientists Happy: Creating Easy to Install Scientific Python Packages.</td><td>Jonathan Helmus</td><td>poster</td></tr>
- <tr><td>imagecube: image processing package in Astronomical Python</td><td>Jeff Taylor</td><td>astro</td></tr>
- <tr><td>Advanced 3D Seismic Visualization in Python</td><td>Joe Kington</td><td>geo</td></tr>
- <tr><td>How to open science by connecting the tools you use or develop to the scientists workflow</td><td>Jeffrey Spies</td><td>poster</td></tr>
- <tr><td>Scientific Computing with SciPy for Undergraduate Physics Majors</td><td>Bill Baxter</td><td>edu2</td></tr>
- <tr><td>Python backends for climate science web-apps</td><td>Nicolas  Fauchereau</td><td>gen1</td></tr>
- <tr><td>Integrating pylearn2 and hyperopt: taking deep learning further with hyperparameter optimization</td><td>David Warde-Farley</td><td>gen1</td></tr>
- <tr><td>Real-time Crunching of Petabytes of Geospatial Data with Google Earth Engine</td><td>Tyler Erickson</td><td>gis3</td></tr>
- <tr><td>Building a Dynamic High Performing Particle Tracking Model</td><td>Christopher Barker</td><td>poster</td></tr>
- <tr><td>Functional Standard Library</td><td>Matthew Rocklin</td><td>poster</td></tr>
- <tr><td>Campaign for IT literacy through FOSS and Spoken Tutorials</td><td>Kannan Moudgalya</td><td>edu4</td></tr>
- <tr><td>Light-weight real-time event detection with Python</td><td>Carson Farmer</td><td>gis1</td></tr>
- <tr><td>Urutu A Python based parallel programming library for GPUs</td><td>Aditya Atluri</td><td>poster</td></tr>
- <tr><td>Where Should We Point a 3 Gigapixel Camera?</td><td>Peter Yoachim</td><td>poster</td></tr>
- <tr><td>MASA: A Tool for the Verification of Scientific Software</td><td>Nicholas Malaya</td><td>edu4</td></tr>
- <tr><td>PyMC: Markov chain Monte Carlo in Python</td><td>Chris Fonnesbeck</td><td>gen3</td></tr>
- <tr><td>Reflexive data science on SciPy communities</td><td>Sebastian Benthall</td><td>soc</td></tr>
- <tr><td>Taking Control - Enabling Mathematicians and Scientists</td><td>Matthew Rocklin</td><td>poster</td></tr>
- <tr><td>Automated GUI Generation for Scientific Applications</td><td>Derek Gaston</td><td>poster</td></tr>
- <tr><td>Provisioning research environments</td><td>Sheila Miguez</td><td>edu4</td></tr>
- <tr><td>Reproducible relocatable customizable builds and packaging with HashDist</td><td>Aron Ahmadia</td><td>gen2</td></tr>
- <tr><td>Python for economists (and other social scientists!)</td><td>David Pugh</td><td>edu3</td></tr>
- <tr><td>Plasticity in OOF</td><td>Andrew Reid</td><td>eng</td></tr>
- <tr><td>Gradient Boosted Regression Trees in scikit-learn</td><td>Peter Prettenhofer</td><td>gen1</td></tr>
- <tr><td>ConceptNet: A Domain-General Semantic Model (and How to Build It)</td><td>Rob Speer</td><td>poster</td></tr>
- <tr><td>Spatial-Temporal Prediction of Climate Change Impacts using geopredict scikit-learn and GDAL</td><td>Matthew Perry</td><td>gis2</td></tr>
- <tr><td>Transient detection and image analysis pipeline for TOROS project</td><td>Martin Beroiz</td><td>astro</td></tr>
- <tr><td>Analyzing potentiometric surface rasters of the Floridan Aquifer with ArcPy and SciPy/NumPy.</td><td>Jeff Jones</td><td>poster</td></tr>
- <tr><td>Python in X-ray Astronomy</td><td>Gerrit Schellenberger</td><td>poster</td></tr>
- <tr><td>How interactive visualization led to insights in digital holographic microscopy</td><td>Rebecca Perry</td><td>viz</td></tr>
- <tr><td>Pyadisi - A Python package for animal locomotion studies</td><td>Isaac Yeaton</td><td>poster</td></tr>
- <tr><td>Teaching Python to undergraduate students</td><td>Dominik Klaes</td><td>edu3</td></tr>
- <tr><td>Activity detection from GPS tracker data</td><td>Jan Vandrol</td><td>gis4</td></tr>
- <tr><td>Integrating IPython into Large-Scale Development Environments</td><td>Zachary H. Jones</td><td>poster</td></tr>
- <tr><td>pySI: A Python Framework for Spatial Interaction Modelling</td><td>Taylor Oshan</td><td>gis4</td></tr>
- <tr><td>Teaching Phase Transformations Using FiPy</td><td>Jonathan Guyer</td><td>poster</td></tr>
- <tr><td>scikit-bio: core bioinformatics data structures and algorithms in Python</td><td>J Gregory Caporaso</td><td>bioinfo</td></tr>
- <tr><td>GeoPandas: Geospatial data + pandas</td><td>Kelsey Jordahl</td><td>gis1</td></tr>
- <tr><td>A Common Scientific Compute Environment for Research and Education</td><td>Dav Clark</td><td>edu1</td></tr>
- <tr><td>Using PyNIO and MPI for Python to help solve a big data problem for the CESM</td><td>David Brown</td><td>gis3</td></tr>
- <tr><td>You Win or You SciPy</td><td>Anthony Scopatz</td><td>poster</td></tr>
- <tr><td>Mapping Networks of Violence</td><td>Evan Misshula</td><td>soc</td></tr>
- <tr><td>HoloPy: Holograpy and Light Scattering in Python</td><td>Tom Dimiduk</td><td>viz</td></tr>
- <tr><td>Deploying Python tools to GIS users</td><td>Shaun Walbridge</td><td>gis3</td></tr>
- <tr><td>Creating a browser-based virtual computer lab for classroom instruction</td><td>Ramalingam Saravanan</td><td>edu2</td></tr>
- <tr><td>An community collection of decoders for instrument-specific data formats</td><td>Joe Young</td><td>poster</td></tr>
- <tr><td>Modeling the global shipping trade using a Python-based analysis stack</td><td>Shaun Walbridge</td><td>poster</td></tr>
-   </tbody>
-</table>
+<h2>Accepted Presentations</h2>
 
+<p> Accepted poster presentations are listed at 
+<a 
+  href="https://conference.scipy.org/scipy2014/posters/">conference.scipy.org/scipy2014/posters</a>.
 
-<hr/>
+<p> The schedulte of talks is listed within the full schedule at  
+<a 
+  href="https://conference.scipy.org/scipy2014/schedule/">conference.scipy.org/scipy2014/schedule</a>.
+
+<h2>Call for Submissions (now closed)</h2>
+
+<p>SciPy 2014, the thirteenth annual Scientific Computing with Python
+conference, will be held this July 6th-12th in Austin, Texas. SciPy
+is a community dedicated to the advancement of scientific computing
+through open source Python software for mathematics, science, and
+engineering. The annual SciPy Conference allows participants from
+academic, commercial, and governmental organizations to showcase their
+latest projects, learn from skilled users and developers, and
+collaborate on code development.</p>
+
+<p><strong>We invite proposals for 20 minute talk and poster presentation by April 1, 2014</strong></p>
+
+<h3>Specialized Tracks</h3>
+
+<p>This year we are happy to announce two specialized tracks that run in parallel to
+the general conference:</p>
+
+<h3>Scientific Computing in Education</h3>
 
 <h2>Call for Submissions</h2>
 

--- a/scipy2014/templates/participate/presentations.html
+++ b/scipy2014/templates/participate/presentations.html
@@ -18,11 +18,13 @@
 
 <p> Accepted poster presentations are listed at 
 <a 
-  href="https://conference.scipy.org/scipy2014/posters/">conference.scipy.org/scipy2014/posters</a>.
+  href="https://conference.scipy.org/scipy2014/posters/">conference.scipy.org/scipy2014/posters</a>. 
+</p>
 
 <p> The schedulte of talks is listed within the full schedule at  
 <a 
   href="https://conference.scipy.org/scipy2014/schedule/">conference.scipy.org/scipy2014/schedule</a>.
+</p>
 
 <h2>Call for Submissions (now closed)</h2>
 


### PR DESCRIPTION
Hi folks, we're fielding some emails because the list of accepted posters on the participate page was out of date. I wonder if you could merge this change that points folks to the right place instead?
